### PR TITLE
Fix execution when "Null Input" is selected

### DIFF
--- a/assets/js/controllers.js
+++ b/assets/js/controllers.js
@@ -48,7 +48,7 @@ angular.module('jqplay.controllers', []).controller('JqplayCtrl', function Jqpla
   };
 
   $scope.delayedRun = function(jq) {
-    if ($scope.input.$valid) {
+    if ($scope.input.$valid || $filter('filter')($scope.jq.o, {name: "null-input"}).enabled) {
       if ($scope.runTimeout != null) {
         $timeout.cancel($scope.runTimeout);
         $scope.runTimeout = null;


### PR DESCRIPTION
Allow jq execution with an empty JSON input when the "Null Input" option is selected.
Resolve #76