### PR TITLE
Add `spellcheck="false"` to filter input

### DIFF
--- a/assets/index.tmpl
+++ b/assets/index.tmpl
@@ -40,7 +40,7 @@
           <div class="col-sm-12 col-md-6">
             <form name="input" role="form" novalidate>
                 <label for="filter">Filter</label>
-                <input type="text" class="form-control" id="filter" name="q" ng-model="jq.q" autofocus ng-required="true">
+                <input type="text" class="form-control" id="filter" name="q" ng-model="jq.q" autofocus ng-required="true" spellcheck="false">
                 <br>
                 <label for="json">JSON</label>
                 <div ui-ace="{


### PR DESCRIPTION
As well as preventing code being highlighted for spelling errors, this prevents macOS/iOS from using smart quotes, so enters "this" instead of “this”