### PR TITLE
add sort-keys

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -76,7 +76,7 @@ header a {
 .json-editor {
   border: 1px solid #DDD;
   width: 100%;
-  height: 340px;
+  height: 368px;
 }
 
 .result-editor {
@@ -85,8 +85,16 @@ header a {
   height: 487px;
 }
 
+#optionsGroup {
+  font-size: 8px;
+}
+
+#optionsGroup span {
+  padding-right: 2px;
+}
+
 #optionsGroup input {
-  margin: -0.77em 0.1em 0 0.7em;
+  margin: 2px;
 }
 
 #optionsGroup label {

--- a/assets/index.tmpl
+++ b/assets/index.tmpl
@@ -58,7 +58,8 @@
           </div> <!-- end col -->
 
           <div class="col-sm-12 col-md-6">
-            <div id="optionsGroup" class="pull-right">
+            <label for="result">Result</label>
+            <div id="optionsGroup">
               <div>
                 <span ng-repeat="option in jq.o | orderBy:'name'">
                   <input type="checkbox" id="{{option.name}}" value="{{option.name}}" ng-model="option.enabled">
@@ -67,7 +68,6 @@
                 </span>
               </div>
             </div>
-            <label for="result">Result</label>
             <div ui-ace="{
               theme:'github',
               mode: 'jsoniq',

--- a/assets/js/controllers.js
+++ b/assets/js/controllers.js
@@ -6,6 +6,7 @@ angular.module('jqplay.controllers', []).controller('JqplayCtrl', function Jqpla
     { name: "compact-output", enabled: false },
     { name: "raw-input", enabled: false },
     { name: "raw-output", enabled: false },
+    { name: "sort-keys", enabled: false },
   ];
   $scope.cmd = "jq ''";
   $scope.result = "";

--- a/jq/jq.go
+++ b/jq/jq.go
@@ -27,7 +27,7 @@ var (
 		"compact-output": struct{}{},
 		"raw-input":      struct{}{},
 		"raw-output":     struct{}{},
-		"sort-keys":     struct{}{},
+		"sort-keys":      struct{}{},
 	}
 )
 

--- a/jq/jq.go
+++ b/jq/jq.go
@@ -27,6 +27,7 @@ var (
 		"compact-output": struct{}{},
 		"raw-input":      struct{}{},
 		"raw-output":     struct{}{},
+		"sort-keys":     struct{}{},
 	}
 )
 


### PR DESCRIPTION
Just adding the `--sort-keys` command line option

This command line option is useful when comparing 2 json objects where fields are in a different order, so wondering if it makes sense to add this to jq play