### PR TITLE
Bump jq version to 1.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu as jqbuilder
 
-ARG JQ_TAG=jq-1.7
+ARG JQ_TAG=jq-1.7.1
 
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true \


### PR DESCRIPTION
Bump jq version to 1.7.1: https://github.com/jqlang/jq/releases/tag/jq-1.7.1