### PR TITLE
Restrict resource usage when shelling out `jq`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,18 @@ RUN git clone --recurse-submodules https://github.com/jqlang/jq.git && \
     --prefix=/usr/local && \
     make install
 
+FROM golang:latest as gotest
+
+COPY --from=jqbuilder /usr/local/bin/jq /usr/local/bin/jq
+
+WORKDIR $GOPATH/src/github.com/owenthereal/jqplay
+
+ARG TIMESTAMP
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    go test ./... -count=1 -race -v
+
 FROM golang:latest as gobuilder
 ARG TARGETOS TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,11 @@ build:
 .PHONY: test
 test:
 	docker \
+		buildx \
 		build \
 		--rm \
-		-f Dockerfile.test \
+		--build-arg TIMESTAMP=$$(date +%s) \
+		--target gotest \
 		.
 
 .PHONY: vet

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,6 @@ docker_build:
 docker_push: docker_build
 	docker buildx build --rm -t $(REPO):$(TAG) --push .
 
-.PHONY: setup
-setup:
-	dropdb --if-exists jqplay
-	createdb jqplay
-	psql -d jqplay -f server/db.sql
-
 .PHONY: start
 start:
 	docker compose up --build --force-recreate

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,11 @@ build:
 
 .PHONY: test
 test:
-	go test ./... -coverprofile=jqplay.c.out -covermode=atomic -count=1 -race -v
-
+	docker \
+		build \
+		--rm \
+		-f Dockerfile.test \
+		.
 
 .PHONY: vet
 vet:

--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,14 @@ require (
 	github.com/joeshaw/envdecode v0.0.0-20200121155833-099f1fc765bd
 	github.com/oklog/run v1.1.1-0.20200508094559-c7096881717e
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.8.3
 	github.com/unrolled/secure v1.14.0
 )
 
 require (
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -37,12 +39,14 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
-	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/net v0.19.0 // indirect
+	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,9 @@ github.com/oklog/run v1.1.1-0.20200508094559-c7096881717e h1:bxQ+jj+8fdl9112bovU
 github.com/oklog/run v1.1.1-0.20200508094559-c7096881717e/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -215,8 +216,8 @@ golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
-golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
+golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -237,8 +238,8 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/jq/jq.go
+++ b/jq/jq.go
@@ -96,15 +96,31 @@ func (j JQ) String() string {
 	return fmt.Sprintf("j=%s, q=%s, o=%v", j.J, j.Q, j.Opts())
 }
 
+func NewJQExec() *JQExec {
+	return &JQExec{
+		ResourceLimiter: &resourceLimiter{
+			MemoryLimit:  limitMemory,
+			CPUTimeLimit: limitCPUTime,
+		},
+	}
+}
+
+const (
+	limitMemory  uint64 = 10 * 1024 * 1024 // 10 MiB
+	limitCPUTime uint64 = 10               // 10 percentage
+)
+
 type ResourceLimiter interface {
 	LimitResources(proc *os.Process) error
 }
 
-type NoResourceLimiter struct {
+type resourceLimiter struct {
+	MemoryLimit  uint64
+	CPUTimeLimit uint64
 }
 
-func (r *NoResourceLimiter) LimitResources(proc *os.Process) error {
-	return nil
+func (r *resourceLimiter) LimitResources(proc *os.Process) error {
+	return limitResources(proc, r.MemoryLimit, r.CPUTimeLimit)
 }
 
 type JQExec struct {

--- a/jq/jq_darwin.go
+++ b/jq/jq_darwin.go
@@ -2,8 +2,8 @@
 
 package jq
 
-func NewJQExec() *JQExec {
-	return &JQExec{
-		ResourceLimiter: &NoResourceLimiter{},
-	}
+import "os"
+
+func limitResources(proc *os.Process, memoryLimit, cpuLimit uint64) error {
+	return nil
 }

--- a/jq/jq_darwin.go
+++ b/jq/jq_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package jq
+
+func NewJQExec() *JQExec {
+	return &JQExec{
+		ResourceLimiter: &NoResourceLimiter{},
+	}
+}

--- a/jq/jq_linux.go
+++ b/jq/jq_linux.go
@@ -1,0 +1,48 @@
+//go:build linux
+
+package jq
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	limitMemory  = 1 * 1024 * 1024 // 1 MiB
+	limitCPUTime = 10              // 50 percentage
+)
+
+func NewJQExec() *JQExec {
+	return &JQExec{
+		ResourceLimiter: &LinuxResourceLimiter{
+			MemoryLimit: limitMemory,
+			CPULImit:    limitCPUTime,
+		},
+	}
+}
+
+type LinuxResourceLimiter struct {
+	MemoryLimit int
+	CPULImit    int
+}
+
+func (r *LinuxResourceLimiter) LimitResources(proc *os.Process) {
+	limitResources(proc)
+}
+
+func limitResources(proc *os.Process) {
+	if proc == nil {
+		return
+	}
+
+	pid := proc.Pid
+
+	// limit address space
+	lim := syscall.Rlimit{limitMemory, limitMemory}
+	syscall.Syscall6(syscall.SYS_PRLIMIT64, uintptr(pid), syscall.RLIMIT_AS, uintptr(unsafe.Pointer(&lim)), 0, 0, 0)
+
+	// limit cpu time
+	lim = syscall.Rlimit{limitCPUTime, limitCPUTime}
+	syscall.Syscall6(syscall.SYS_PRLIMIT64, uintptr(pid), syscall.RLIMIT_CPU, uintptr(unsafe.Pointer(&lim)), 0, 0, 0)
+}

--- a/jq/jq_linux.go
+++ b/jq/jq_linux.go
@@ -8,26 +8,7 @@ import (
 	"unsafe"
 )
 
-const (
-	limitMemory  uint64 = 1 * 1024 * 1024 // 1 MiB
-	limitCPUTime uint64 = 10              // 50 percentage
-)
-
-func NewJQExec() *JQExec {
-	return &JQExec{
-		ResourceLimiter: &LinuxResourceLimiter{
-			MemoryLimit: limitMemory,
-			CPULImit:    limitCPUTime,
-		},
-	}
-}
-
-type LinuxResourceLimiter struct {
-	MemoryLimit uint64
-	CPULImit    uint64
-}
-
-func (r *LinuxResourceLimiter) LimitResources(proc *os.Process) error {
+func limitResources(proc *os.Process, memoryLimit, cpuLimit uint64) error {
 	if proc == nil {
 		return nil
 	}
@@ -36,7 +17,7 @@ func (r *LinuxResourceLimiter) LimitResources(proc *os.Process) error {
 	var err error
 
 	// limit address space
-	lim := syscall.Rlimit{Cur: r.MemoryLimit, Max: r.MemoryLimit}
+	lim := syscall.Rlimit{Cur: memoryLimit, Max: memoryLimit}
 	_, _, errno := syscall.Syscall6(syscall.SYS_PRLIMIT64, uintptr(pid), syscall.RLIMIT_AS, uintptr(unsafe.Pointer(&lim)), 0, 0, 0)
 	err = errnoToErr(errno)
 	if err != nil {
@@ -44,7 +25,7 @@ func (r *LinuxResourceLimiter) LimitResources(proc *os.Process) error {
 	}
 
 	// limit cpu time
-	lim = syscall.Rlimit{Cur: r.CPULImit, Max: r.CPULImit}
+	lim = syscall.Rlimit{Cur: cpuLimit, Max: cpuLimit}
 	_, _, errno = syscall.Syscall6(syscall.SYS_PRLIMIT64, uintptr(pid), syscall.RLIMIT_CPU, uintptr(unsafe.Pointer(&lim)), 0, 0, 0)
 	err = errnoToErr(errno)
 

--- a/server/handler.go
+++ b/server/handler.go
@@ -1,20 +1,14 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/owenthereal/jqplay/config"
 	"github.com/owenthereal/jqplay/jq"
 	"github.com/sirupsen/logrus"
-)
-
-const (
-	jqExecTimeout = 5 * time.Second
 )
 
 type JQHandlerContext struct {
@@ -49,14 +43,11 @@ func (h *JQHandler) handleJqPost(c *gin.Context) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(c.Request.Context(), jqExecTimeout)
-	defer cancel()
-
 	c.Header("Content-Type", "text/plain; charset=utf-8")
 
 	// Evaling into ResponseWriter sets the status code to 200
 	// appending error message in the end if there's any
-	if err := h.JQExec.Eval(ctx, jq, c.Writer); err != nil {
+	if err := h.JQExec.Eval(c.Request.Context(), jq, c.Writer); err != nil {
 		fmt.Fprint(c.Writer, err.Error())
 		h.logger(c).WithError(err).Info("jq error")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -11,8 +11,13 @@ import (
 	"github.com/oklog/run"
 	"github.com/owenthereal/jqplay"
 	"github.com/owenthereal/jqplay/config"
+	"github.com/owenthereal/jqplay/jq"
 	"github.com/owenthereal/jqplay/server/middleware"
 	log "github.com/sirupsen/logrus"
+)
+
+const (
+	requestTimeout = 5 * time.Second
 )
 
 func New(c *config.Config) *Server {
@@ -66,7 +71,7 @@ func newHTTPServer(cfg *config.Config, db *DB) (*http.Server, error) {
 
 	router := gin.New()
 	router.Use(
-		middleware.Timeout(8*time.Second),
+		middleware.Timeout(requestTimeout),
 		middleware.LimitContentLength(10),
 		middleware.Secure(cfg.IsProd()),
 		middleware.RequestID(),
@@ -75,7 +80,7 @@ func newHTTPServer(cfg *config.Config, db *DB) (*http.Server, error) {
 	)
 	router.SetHTMLTemplate(tmpl)
 
-	h := &JQHandler{Config: cfg, DB: db}
+	h := &JQHandler{JQExec: jq.NewJQExec(), Config: cfg, DB: db}
 
 	router.StaticFS("/assets", http.FS(jqplay.PublicFS))
 	router.GET("/", h.handleIndex)

--- a/server/server.go
+++ b/server/server.go
@@ -66,7 +66,7 @@ func newHTTPServer(cfg *config.Config, db *DB) (*http.Server, error) {
 
 	router := gin.New()
 	router.Use(
-		middleware.Timeout(25*time.Second),
+		middleware.Timeout(8*time.Second),
 		middleware.LimitContentLength(10),
 		middleware.Secure(cfg.IsProd()),
 		middleware.RequestID(),


### PR DESCRIPTION
Restrict resource usage when shelling out `jq`